### PR TITLE
Respect typed arrays and dictionaries inside objects

### DIFF
--- a/addons/picklegd/pickler.gd
+++ b/addons/picklegd/pickler.gd
@@ -379,5 +379,14 @@ func post_unpickle_object(dict: Dictionary):
 		else:
 			for propname in pc.allowed_properties:
 				if dict.has(propname):
-					obj.set(propname, post_unpickle(dict[propname]))
+					var value = post_unpickle(dict[propname])
+					match typeof(value):
+						TYPE_ARRAY:
+							var arr = obj.get(propname) as Array
+							arr.assign(value)
+						TYPE_DICTIONARY:
+							var d2 = obj.get(propname) as Dictionary
+							d2.assign(value)
+						_:
+							obj.set(propname, value)
 	return obj

--- a/addons/picklegd/test/custom_class_typed_elements.gd
+++ b/addons/picklegd/test/custom_class_typed_elements.gd
@@ -1,0 +1,5 @@
+class_name CustomClassTypedElements
+extends RefCounted
+
+var arr: Array[int] = [7, 8, 9]
+var dee: Dictionary[String, float] = {"a": 5.0, "b": 6.0}

--- a/addons/picklegd/test/custom_class_typed_elements.gd.uid
+++ b/addons/picklegd/test/custom_class_typed_elements.gd.uid
@@ -1,0 +1,1 @@
+uid://crmoemcr2tgsi

--- a/addons/picklegd/test/pickler_test.gd
+++ b/addons/picklegd/test/pickler_test.gd
@@ -357,3 +357,55 @@ func test_builtins_not_omitted():
 	assert_int(pre.size()).is_greater(1)
 	var u = _pickler.post_unpickle(pre)
 	assert_object(u).is_equal(obj)
+
+
+func test_typed_arrays():
+	var a: Array[int] = [1, 2, 3, 4]
+	var p = _pickler.pickle(a)
+	var u = _pickler.unpickle(p)
+	assert_array(u).contains_exactly(a)
+
+
+func test_typed_dictionaries():
+	var d: Dictionary[int, String] = {
+		1: "foo",
+		3: "baz",
+	}
+	var p = _pickler.pickle(d)
+	var u = _pickler.unpickle(p)
+	check_are_equal(d, u)
+
+
+func test_typed_elements_in_objects():
+	var reg = _pickler.register_custom_class(CustomClassTypedElements)
+	var o = CustomClassTypedElements.new()
+	o.arr.append_array([1, 2, 3, 5, 7])
+	o.dee.assign({"one": 1.0, "dos": 2.2, "trace": 3.33})
+	var p = _pickler.pickle(o)
+	var u = _pickler.unpickle(p)
+	check_are_equal(o, u)
+
+
+func test_typed_elements_in_objects_no_defaults():
+	_pickler.serialize_defaults = false
+	var reg = _pickler.register_custom_class(CustomClassTypedElements)
+	var o = CustomClassTypedElements.new()
+
+	# don't serialize defaults
+	var p = _pickler.pickle(o)
+	var u = _pickler.unpickle(p)
+	check_are_equal(o, u)
+
+	# overwrite defaults
+	o.arr.append_array([1, 2, 3, 5, 7])
+	o.dee.assign({"one": 1.0, "dos": 2.2, "trace": 3.33})
+	p = _pickler.pickle(o)
+	u = _pickler.unpickle(p)
+	check_are_equal(o, u)
+
+	# clear them
+	o.arr.clear()
+	o.dee.clear()
+	p = _pickler.pickle(o)
+	u = _pickler.unpickle(p)
+	check_are_equal(o, u)


### PR DESCRIPTION
Fixes #1 . Use `Array.assign` and `Dictionary.assign` so that the container's elements get copied over even though the original `Array`'s type information gets clobbered in the pickling/unpickling process.